### PR TITLE
WEBRTC-1626 Allow updateStream() and subscribe to specific streamKeys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ android {
 dependencies {
 
     // SDK:
-    implementation 'com.github.team-telnyx:telnyx-video-android:v0.0.1-beta'
+    implementation 'com.github.team-telnyx:telnyx-video-android:v0.0.2'
 
     implementation 'commons-codec:commons-codec:1.13'
 

--- a/app/src/androidTest/java/com/telnyx/meet/ui/ManageRoomDetailsActivityTest.kt
+++ b/app/src/androidTest/java/com/telnyx/meet/ui/ManageRoomDetailsActivityTest.kt
@@ -111,6 +111,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).waitUntilVisible(15000).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -140,6 +141,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -219,6 +221,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -251,6 +254,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -287,6 +291,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -323,6 +328,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(
@@ -363,6 +369,7 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
             onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(25000).perform(
                 scrollTo<RoomAdapter.RoomHolder>(
                     hasDescendant(

--- a/app/src/main/java/com/telnyx/meet/ui/ParticipantsFragment.kt
+++ b/app/src/main/java/com/telnyx/meet/ui/ParticipantsFragment.kt
@@ -55,8 +55,8 @@ class ParticipantsFragment : Fragment() {
         }
 
         roomsViewModel.getParticipantStreamChanged()
-            .observe(viewLifecycleOwner) { participantChangedStreams ->
-                participantChangedStreams?.let {
+            .observe(viewLifecycleOwner) { participantChangedStreamsEvent ->
+                participantChangedStreamsEvent.getContentIfNotHandled()?.let {
                     participantsAdapter.notifyDataSetChanged()
                 }
             }

--- a/app/src/main/java/com/telnyx/meet/ui/RoomCreateFragment.kt
+++ b/app/src/main/java/com/telnyx/meet/ui/RoomCreateFragment.kt
@@ -75,7 +75,7 @@ class RoomCreateFragment @Inject constructor(
                 mRoomName = it.unique_name
                 tv_room_id.text = mRoomId
                 tv_room_name.text = mRoomName
-                roomsViewModel.createTokenForRoom(it.id)
+                roomsViewModel.createTokenForRoom(it.id, mParticipantName)
             }
         }
 
@@ -88,7 +88,7 @@ class RoomCreateFragment @Inject constructor(
                     tv_room_token.text = tokenInfo.token
                     mRoomId?.let {
                         setRoomSpecificObservers()
-                        roomsViewModel.connectToRoom(mParticipantName)
+                        roomsViewModel.connectToRoom()
                     }
                 }
             }
@@ -156,7 +156,6 @@ class RoomCreateFragment @Inject constructor(
                 mRefreshToken!!,
                 mRefreshTimer!!
             )
-            roomsViewModel.shouldAcceptFirstSharingInfo = false
             navigator.navController.navigate(action)
         }
     }
@@ -169,7 +168,7 @@ class RoomCreateFragment @Inject constructor(
                 tv_room_name.text = mRoomName
                 room_name_et.setText(mRoomName)
             }
-            roomsViewModel.createTokenForRoom(roomId)
+            roomsViewModel.createTokenForRoom(roomId, mParticipantName)
             buttonCreateRoom.isEnabled = true
             room_name_et.addTextChangedListener {
                 buttonCreateRoom.isEnabled = true

--- a/app/src/main/java/com/telnyx/meet/ui/adapters/ParticipantTileAdapter.kt
+++ b/app/src/main/java/com/telnyx/meet/ui/adapters/ParticipantTileAdapter.kt
@@ -14,9 +14,14 @@ import timber.log.Timber
 interface ParticipantTileListener {
     fun onItemClicked(model: Participant)
     fun notifyTileSelfSurfaceId(participantSurface: SurfaceViewRenderer)
-    fun notifyTileSurfaceId(participantSurface: SurfaceViewRenderer, participantId: String)
-    fun unsubscribeTileToStream(participantId: String)
-    fun subscribeTileToStream(participantId: String)
+    fun notifyTileSurfaceId(
+        participantSurface: SurfaceViewRenderer,
+        participantId: String,
+        streamKey: String
+    )
+
+    fun unsubscribeTileToStream(participantId: String, streamKey: String)
+    fun subscribeTileToStream(participantId: String, streamKey: String)
     fun notifyExtraParticipants(extraParticipants: Int)
 }
 
@@ -46,7 +51,7 @@ class ParticipantTileAdapter(private val participantTileListener: ParticipantTil
 
     private fun pauseRemainingParticipants(participantsNotVisible: List<Participant>) {
         participantsNotVisible.forEach {
-            participantTileListener.unsubscribeTileToStream(it.participantId)
+            participantTileListener.unsubscribeTileToStream(it.participantId, "self")
         }
     }
 
@@ -59,8 +64,9 @@ class ParticipantTileAdapter(private val participantTileListener: ParticipantTil
         participants.find { it.participantId == participant.participantId }?.let {
             it.id = participant.id
             it.externalUsername = participant.externalUsername
-            it.publishingId = participant.publishingId
-            it.sharingId = participant.sharingId
+            it.streams = participant.streams
+            it.audioBridgeId = participant.audioBridgeId
+            it.canReceiveMessages = participant.canReceiveMessages
         } ?: run {
             Timber.tag("ParticipantTileAdapter")
                 .d("Adding participant: ${participant.participantId}")
@@ -115,7 +121,7 @@ class ParticipantTileAdapter(private val participantTileListener: ParticipantTil
         fun bind(model: Participant, participantTileListener: ParticipantTileListener) {
             Timber.tag("ParticipantTileAdapter").d("onBind() isSelf: ${model.isSelf}")
             itemView.participant_tile_id.text =
-                model.participantId.substring(31)
+                model.participantId.substring(0, 5)
             itemView.participant_tile_name.text = model.externalUsername.toString()
 
             Timber.tag("ParticipantTileAdapter")
@@ -136,29 +142,30 @@ class ParticipantTileAdapter(private val participantTileListener: ParticipantTil
             if (model.isSelf) participantTileListener.notifyTileSelfSurfaceId(itemView.participant_tile_surface)
 
             // TODO review this logic: will only subscribe to audio, if video is enabled as well
-            when (model.videoEnabled) {
+            when (model.streams.find { it.streamKey == "self" }?.videoEnabled) {
                 StreamStatus.ENABLED -> {
                     Timber.tag("ParticipantTileAdapter").d("onBind() STARTED")
-                    participantTileListener.subscribeTileToStream(model.participantId)
+                    participantTileListener.subscribeTileToStream(model.participantId, "self")
                     itemView.participant_tile_surface.visibility = View.VISIBLE
                     itemView.participant_tile_place_holder.visibility = View.GONE
-                    model.videoTrack?.addSink(itemView.participant_tile_surface)
-                    model.videoTrack?.setEnabled(true)
+                    model.streams.find { it.streamKey == "self" }?.videoTrack?.addSink(itemView.participant_tile_surface)
+                    model.streams.find { it.streamKey == "self" }?.videoTrack?.setEnabled(true)
                     participantTileListener.notifyTileSurfaceId(
                         itemView.participant_tile_surface,
-                        model.participantId
+                        model.participantId,
+                        "self"
                     )
                 }
                 else -> {
                     Timber.tag("ParticipantTileAdapter").d("onBind() PAUSED")
                     itemView.participant_tile_surface.visibility = View.GONE
                     itemView.participant_tile_place_holder.visibility = View.VISIBLE
-                    participantTileListener.unsubscribeTileToStream(model.participantId)
+                    participantTileListener.unsubscribeTileToStream(model.participantId, "self")
                 }
             }
-
-            when (model.audioEnabled) {
 /*
+            when (model.streams.find { it.streamKey == "self" }?.audioEnabled) {
+            }
                 StreamStatus.ENABLED -> {
                     participantTileListener.subscribeTileToStream(model.participantId)
                 }
@@ -166,7 +173,6 @@ class ParticipantTileAdapter(private val participantTileListener: ParticipantTil
                     Timber.tag("ParticipantTileAdapter").d("onBind() Do nothing")
                 }
 */
-            }
             itemView.setOnClickListener {
                 participantTileListener.onItemClicked(model)
             }

--- a/app/src/main/java/com/telnyx/meet/ui/adapters/ParticipantsAdapter.kt
+++ b/app/src/main/java/com/telnyx/meet/ui/adapters/ParticipantsAdapter.kt
@@ -52,13 +52,13 @@ class ParticipantsAdapter : RecyclerView.Adapter<ParticipantsAdapter.Participant
                 itemView.isSpeakingIcon_id.visibility = View.INVISIBLE
             }
 
-            if (model.audioEnabled == StreamStatus.ENABLED) {
+            if (model.streams.find { it.streamKey == "self" }?.audioEnabled == StreamStatus.ENABLED) {
                 itemView.isMutedIcon_id.setImageResource(R.drawable.ic_mic)
             } else {
                 itemView.isMutedIcon_id.setImageResource(R.drawable.ic_mic_off)
             }
 
-            if (model.videoEnabled == StreamStatus.ENABLED) {
+            if (model.streams.find { it.streamKey == "self" }?.videoEnabled == StreamStatus.ENABLED) {
                 itemView.isVideoIcon_id.setImageResource(R.drawable.ic_camera)
             } else {
                 itemView.isVideoIcon_id.setImageResource(R.drawable.ic_camera_off)

--- a/app/src/main/java/com/telnyx/meet/ui/utilities/Utils.kt
+++ b/app/src/main/java/com/telnyx/meet/ui/utilities/Utils.kt
@@ -73,3 +73,12 @@ fun Activity.showSystemUI() {
 fun Activity.isFullScreenEnabled(): Boolean {
     return window.attributes.flags and WindowManager.LayoutParams.FLAG_FULLSCREEN != 0
 }
+
+fun randomInt(length: Int): Int {
+    val characters = "0123456789"
+    val stringBuilder = StringBuilder(length)
+    repeat(length) {
+        stringBuilder.append(characters[Random().nextInt(characters.length)])
+    }
+    return Integer.parseInt(stringBuilder.toString())
+}


### PR DESCRIPTION
The purpose of this change is to address two technical debts that raised from creating the documentation:

- The first one is related to the way "ExternalData" was provided from the client app into the SDK. This external data is currently an Integer *id* and a Sting *participantName*
- Second is related to the fact that we're now able to subscribe to a specific stream using **streamKey**. Thus, we can provide a specific **streamKey** as well to name our own stream

## :older_man: :baby: Behaviors
### Before changes

#### ExternalData issue
Before this change, we provided the SDK the *participantName* only, by using the method *setClientName* before issuing *connect()* method
```kotlin
room.setClientName(mParticipantName)
room.connect()
```
#### StreamKey issue
We could separate this issue in **publisher** side of the issue and **subscriber** side of the issue
- As **publishers**: We were providing an *id* for that *PublishConfigHelper* instance, but we weren't using it to send a *streamKey* in the *join* message

```
// RoomFragment
publishConfigHelper =
      PublishConfigHelper(
      requireContext(),
      CameraDirection.FRONT,
      MEDIA_STREAM_HELPER_KEY // Provided but never used
)
publishConfigHelper.createAudioTrack(true, AUDIO_TRACK_KEY)  // Only for naming the track
roomsViewModel.publish(publishConfigHelper)
```

The method *removeStream(trackKey)* was used to remove a track from the only stream we were publishing that was "self", therefore the actions didn't remove the stream nor the peer connection for it. Only removing a track.

- As **subscribers** we were considering the remote publishers will also be either **"self"** or **"presentation"**. Meaning we weren't prepared to subscribe to any other name convention nor to a remote participant with more than two streams, and we used "isPresentation" as a boolean to select between only those two possible publishers.

```
// RoomsViewModel
fun subscribe(
    participantId: String,
    isPresentation: Boolean,
    key: String,
    streamConfig: StreamConfig
) {
    room.addSubscription(participantId, isPresentation, key, streamConfig)
}
```

We had also an observable to report a sharing participant, but SDK will know nothing about what kind of stream users are streaming.

```
fun getParticipantSharingChanged(): MutableLiveData<Event<Participant>> =
    room.getParticipantSharingChanged()
```

### After changes

#### ExternalData issue
We now provide the *id* and *participantName* as soon as we also provide the *roomId* and *tokenId*.
We will create an instance of ExternalData in the client, and provide it in the *Room* constructor. Later we will only issue *room.connect()*
```
room = Room(
      context = context,
      roomId = UUID.fromString(roomId),
      roomToken = tokenInfo.token,
      externalData = ExternalData(randomInt(7), participantName),   <<<<<<<<<<<<
      enableMessages = true
)
room.connect()

```
#### StreamKey issue
- As *publishers* we have now to provide information for *streamKey* and *streamId* along with our *PublishConfigHelper* instance
```
publishConfigHelper =
    PublishConfigHelper(
        requireContext(),
        CameraDirection.FRONT,
        SELF_STREAM_KEY,
        SELF_STREAM_ID
    )
publishConfigHelper.createAudioTrack(true, AUDIO_TRACK_KEY)

room.addStream(publishConfigHelper) //If the stream isn't created

// OR

room.updateStream(publishConfigHelper) //If the stream is created and we're adding/removing a track from publishConfigHelper instance

```
Additionaly we can removeStream, and remove all tracks within that stream
```
room.removeStream("someStreamKey")
```

- As *subscribers* we have replaced the *isPresentation* flag, for the streamKey specific to the stream we need to subscribe to.

```
room.addSubscription(participantId, streamKey, streamConfig)
room.updateSubscription(participantId: String, streamKey: String, streamConfig: StreamConfig)
room.removeSubscription(participantId, streamKey)

```
## ✋ Manual testing
1. Install the app
2. run it normally