### PR TITLE
chore(WEBRTC-1856) Refine firebase tests to remove duplicates and reduce runtime 

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v5.0.2
+        uses: JetBrains/qodana-action@v5.1.0
 
       - uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -67,6 +67,6 @@ jobs:
       - name: Run tests on Firebase Test Lab
         uses: asadmansr/Firebase-Test-Lab-Action@v1.0
         with:
-          arg-spec: 'tests.yml:android-pixel-4'
+          arg-spec: 'tests.yml:android-pixel-2'
         env:
           SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}

--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -26,6 +26,11 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: Update API Key from Secrets
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
+        run: echo API_KEY="$API_KEY" > ./local.properties
+
       - name: Assemble app debug APK
         run: bash ./gradlew assembleDebug --stacktrace
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,9 +74,9 @@ android {
 dependencies {
 
     // SDK:
-    implementation ('com.github.team-telnyx:telnyx-meet-android-sdk:0.2.4@aar'){transitive=true}
+    implementation ('com.github.team-telnyx:telnyx-meet-android-sdk:0.3.0@aar'){transitive=true}
 
-    implementation 'commons-codec:commons-codec:1.13'
+    implementation 'commons-codec:commons-codec:1.15'
 
     implementation deps.webrtc
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,9 @@ plugins {
 }
 apply plugin: 'kotlin-android'
 
+def localProperties = new Properties()
+localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+
 android {
     compileSdkVersion 31
     buildToolsVersion "30.0.3"
@@ -21,23 +24,32 @@ android {
 
         multiDexEnabled true
 
-        //RenderScript
-        renderscriptTargetApi 19
-        renderscriptSupportModeEnabled true
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "java.util.concurrent.atomic.AtomicBoolean", "IS_APP_TESTING", "new java.util.concurrent.atomic.AtomicBoolean(false)"
 
     }
 
     buildTypes {
+        Properties properties = new Properties()
+        if (project.rootProject.file('local.properties').canRead()) {
+            properties.load(project.rootProject.file("local.properties").newDataInputStream())
+        } else {
+            throw new GradleException("Could not read local.properties!")
+        }
+
         release {
+            buildConfigField 'String', "API_KEY", properties.getProperty('API_KEY', '"xxxxx"')
+            resValue('string', "api_key", properties.getProperty('API_KEY', '"xxxxx"'))
+
             testCoverageEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             jniDebuggable true
         }
         debug {
+            buildConfigField 'String', "API_KEY", properties.getProperty('API_KEY', '"xxxxx"')
+            resValue('string', "api_key", properties.getProperty('API_KEY', '"xxxxx"'))
+
             testCoverageEnabled true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -77,8 +89,6 @@ dependencies {
     implementation ('com.github.team-telnyx:telnyx-meet-android-sdk:0.3.0@aar'){transitive=true}
 
     implementation 'commons-codec:commons-codec:1.15'
-
-    implementation deps.webrtc
 
     //leak canary
     //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'

--- a/app/src/androidTest/java/com/telnyx/meet/ui/ManageRoomDetailsActivityTest.kt
+++ b/app/src/androidTest/java/com/telnyx/meet/ui/ManageRoomDetailsActivityTest.kt
@@ -7,6 +7,10 @@ import android.widget.TextView
 import androidx.test.espresso.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.GeneralSwipeAction
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Swipe
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -73,8 +77,6 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
     fun on_B_CreateARoomShowsEmptyNamesScreen() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             onView(withId(R.id.fab)).perform(click())
             onView(withId(R.id.label_room_name)).check(matches(isDisplayed()))
@@ -90,8 +92,6 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
     fun on_C_testEmptyRoomNameCausesError() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             onView(withId(R.id.fab)).perform(click())
             onView(withId(R.id.buttonCreateRoom)).check(matches(isEnabled()))
@@ -105,74 +105,9 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
     }
 
     @Test
-    fun on_E_testAccessToGivenRoom() {
+    fun on_D_testAccessToGivenRoomToggleVideoThenAudioCheckStats() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
-            onView(withId(R.id.see_available_rooms_text)).waitUntilVisible(15000).perform(click())
-            Thread.sleep(2000)
-            onView(withId(R.id.roomsRecycler)).perform(
-                scrollTo<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(roomName)
-                    )
-                )
-            )
-            onView(withId(R.id.roomsRecycler)).perform(
-                actionOnItem<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(
-                            roomName
-                        )
-                    ),
-                    click()
-                )
-            )
-            Thread.sleep(5000)
-            Espresso.pressBack()
-        }
-    }
-
-    @Test
-    fun on_F_testAccessToGivenRoomToggleVideo() {
-        assertDoesNotThrow {
-            activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
-            onView(withId(R.id.see_available_rooms_text)).perform(click())
-            Thread.sleep(2000)
-            onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
-                scrollTo<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(roomName)
-                    )
-                )
-            )
-            onView(withId(R.id.roomsRecycler)).perform(
-                actionOnItem<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(
-                            roomName
-                        )
-                    ),
-                    click()
-                )
-            )
-            onView(withId(R.id.action_camera)).waitUntilVisible(15000).perform(click())
-            Thread.sleep(1000)
-            onView(withId(R.id.action_camera)).perform(click())
-            Thread.sleep(1000)
-            Espresso.pressBack()
-        }
-    }
-
-    @Test
-    fun on_G_testAccessToGivenRoomToggleVideoCheckStats() {
-        assertDoesNotThrow {
-            activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             onView(withId(R.id.participant_name_et)).waitUntilVisible(25000).perform(
                 setTextInTextView("Test Participant"),
@@ -197,6 +132,9 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
                 )
             )
             onView(withId(R.id.action_camera)).waitUntilVisible(15000).perform(click())
+            Thread.sleep(2000)
+            onView(withId(R.id.action_mic)).perform(click())
+            Thread.sleep(2000)
             onView(withId(R.id.participantTileRecycler)).waitUntilVisible(15000).perform(
                 actionOnItem<ParticipantTileAdapter.ParticipantTileHolder>(
                     hasDescendant(
@@ -207,19 +145,23 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
                     click()
                 )
             )
-            Thread.sleep(1000)
+            Thread.sleep(2000)
             onView(withId(R.id.stats_dialog_title)).waitUntilVisible(15000)
                 .check(matches(isDisplayed()))
-            Espresso.pressBack()
+            Thread.sleep(2000)
+            onView(withId(R.id.stats_dialog_id)).waitUntilVisible(15000).perform(customSwipeDown())
+            Thread.sleep(2000)
+            onView(withId(R.id.action_camera)).perform(click())
+            Thread.sleep(2000)
+            onView(withId(R.id.action_mic)).perform(click())
+            Thread.sleep(2000)
         }
     }
 
     @Test
-    fun on_H_testAccessToGivenRoomToggleAudio() {
+    fun on_E_testAccessToGivenRoomToggleAudioThenVideo() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
@@ -240,93 +182,20 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
                 )
             )
             onView(withId(R.id.action_mic)).waitUntilVisible(25000).perform(click())
-            Thread.sleep(1000)
-            onView(withId(R.id.action_mic)).perform(click())
-            Thread.sleep(1000)
-            Espresso.pressBack()
-        }
-    }
-
-    @Test
-    fun on_I_testAccessToGivenRoomToggleAudioThenVideo() {
-        assertDoesNotThrow {
-            activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
-            onView(withId(R.id.see_available_rooms_text)).perform(click())
             Thread.sleep(2000)
-            onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
-                scrollTo<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(roomName)
-                    )
-                )
-            )
-            onView(withId(R.id.roomsRecycler)).perform(
-                actionOnItem<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(
-                            roomName
-                        )
-                    ),
-                    click()
-                )
-            )
-            onView(withId(R.id.action_mic)).waitUntilVisible(25000).perform(click())
-            Thread.sleep(1000)
             onView(withId(R.id.action_camera)).perform(click())
-            Thread.sleep(1000)
-            onView(withId(R.id.action_mic)).perform(click())
-            Thread.sleep(1000)
-            onView(withId(R.id.action_camera)).perform(click())
-            Thread.sleep(1000)
-            Espresso.pressBack()
-        }
-    }
-
-    @Test
-    fun on_J_testAccessToGivenRoomToggleVideoThenAudio() {
-        assertDoesNotThrow {
-            activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
-            onView(withId(R.id.see_available_rooms_text)).perform(click())
             Thread.sleep(2000)
-            onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
-                scrollTo<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(roomName)
-                    )
-                )
-            )
-            onView(withId(R.id.roomsRecycler)).perform(
-                actionOnItem<RoomAdapter.RoomHolder>(
-                    hasDescendant(
-                        withText(
-                            roomName
-                        )
-                    ),
-                    click()
-                )
-            )
-            onView(withId(R.id.action_camera)).waitUntilVisible(25000).perform(click())
-            Thread.sleep(1000)
             onView(withId(R.id.action_mic)).perform(click())
-            Thread.sleep(1000)
+            Thread.sleep(2000)
             onView(withId(R.id.action_camera)).perform(click())
-            Thread.sleep(1000)
-            onView(withId(R.id.action_mic)).perform(click())
-            Thread.sleep(1000)
-            Espresso.pressBack()
+            Thread.sleep(2000)
         }
     }
 
     @Test
-    fun on_K_testAccessToGivenRoomNavToChatSendMessage() {
+    fun on_F_testAccessToGivenRoomNavToChatSendMessage() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(15000).perform(
@@ -358,16 +227,13 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             Thread.sleep(2000)
             onView(withId(R.id.chat_send_btn)).perform(click())
             Thread.sleep(1000)
-            Espresso.pressBack()
         }
     }
 
     @Test
-    fun on_L_testAccessToGivenRoomNavToParticipantsList() {
+    fun on_G_testAccessToGivenRoomNavToParticipantsList() {
         assertDoesNotThrow {
             activityRule.launchActivity(null)
-            onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-            onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
             onView(withId(R.id.see_available_rooms_text)).perform(click())
             Thread.sleep(2000)
             onView(withId(R.id.roomsRecycler)).waitUntilVisible(25000).perform(
@@ -392,15 +258,12 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
             onView(withText("View participants")).waitUntilVisible(15000).perform(click())
             Thread.sleep(2000)
             onView(withId(R.id.participantRecycler)).check(matches(isDisplayed()))
-            Espresso.pressBack()
         }
     }
 
     @Test
-    fun on_O_testParticipantNameNotEmpty() {
+    fun on_H_testParticipantNameNotEmpty() {
         activityRule.launchActivity(null)
-        onView(withId(R.id.join_explainer_text)).check(matches(isDisplayed()))
-        onView(withId(R.id.buttonJoinRoom)).check(matches(isDisplayed()))
         onView(withId(R.id.see_available_rooms_text)).perform(click())
         onView(withId(R.id.participant_name_et)).waitUntilVisible(25000).perform(clearText())
         onView(withId(R.id.fab)).perform(click())
@@ -428,6 +291,15 @@ class ManageRoomDetailsActivityTest : BaseUITest() {
                 return "replace text"
             }
         }
+    }
+
+    private fun customSwipeDown(): ViewAction {
+        return GeneralSwipeAction(
+            Swipe.FAST,
+            GeneralLocation.TOP_CENTER,
+            GeneralLocation.BOTTOM_CENTER,
+            Press.FINGER
+        )
     }
 }
 

--- a/app/src/main/java/com/telnyx/meet/di/NetworkModule.kt
+++ b/app/src/main/java/com/telnyx/meet/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.telnyx.meet.di
 
 import com.google.gson.GsonBuilder
+import com.telnyx.meet.BuildConfig
 import com.telnyx.meet.data.RoomService
 import dagger.Module
 import dagger.Provides
@@ -23,8 +24,7 @@ object NetworkModule {
 
     @Provides
     @ApiKey
-    fun provideApiKey() = "KEY123....."
-
+    fun provideApiKey() = BuildConfig.API_KEY // Replace this...
 
     @Singleton
     @Provides

--- a/app/src/main/res/layout/stats_info_dialog.xml
+++ b/app/src/main/res/layout/stats_info_dialog.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/stats_dialog_id"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/local.properties
+++ b/local.properties
@@ -6,3 +6,4 @@
 # header note.
 #Mon May 30 10:10:40 IST 2022
 sdk.dir=/Users/oliverzimmerman/Library/Android/sdk
+API_KEY="KEY123....."

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Tue May 17 11:48:34 ART 2022
-sdk.dir=/home/lucasp/Android/Sdk
+#Mon May 30 10:10:40 IST 2022
+sdk.dir=/Users/oliverzimmerman/Library/Android/sdk

--- a/tests.yml
+++ b/tests.yml
@@ -1,8 +1,9 @@
-android-pixel-4:
+android-pixel-2:
   type: instrumentation
   app: app-debug.apk
   test: app-debug-androidTest.apk
   device:
-    - version: 28
+    - model: Pixel2
+      version: 29
       locale: 'en'
       orientation: portrait


### PR DESCRIPTION
[WEBRTC-1856 - Refine firebase tests to remove duplicates and reduce runtime](https://telnyx.atlassian.net/browse/WEBRTC-1856)

---
<!-- Describe your changes here -->
This PR refines our pipeline because we were using multiple tests that essentially tested the same thing - this meant a very large and unnecessary run time to test what was essentially the same thing.

eg. 
Test Join Room
Test Join Room and toggle video
Test Join Room and toggle video and audio.
Test Join Room and toggle video and audio check stats

In the case of the above, we removed the first 3. 

I also removed the requirement to run Unit tests before the firebase tests because we do the unit tests as a part of other pipeline runs. 

Finally, we introduce a local property which will be replaced by a Github secret so that the tests can run with a valid API Key

## :older_man: :baby: Behaviors
### Before changes
Unnecessary tests that are testing the same thing 
Running unit tests multiple times when opening a PR 
No valid API key to run the tests

### After changes
Refine tests to reduce run time
Only run unit tests once per PR 
API Key being applied as a Github Secret at runtime

## ✋ Manual testing
1. Run firebase tests locally
